### PR TITLE
refactor: remove unnecessary exception for already loaded assembly an…

### DIFF
--- a/Qurre/Loader.cs
+++ b/Qurre/Loader.cs
@@ -25,7 +25,7 @@ public class Loader : Plugin
 
     public override void Enable()
     {
-        Logger.Raw("[Loader] [Qurre] Initialization...", ConsoleColor.Yellow);
+        Logger.Raw("[Loader] [Qurre] InitialiYellow);
 
         if (!Directory.Exists(Manager.Qurre))
             Directory.CreateDirectory(Manager.Qurre);

--- a/Qurre/Manager.cs
+++ b/Qurre/Manager.cs
@@ -32,9 +32,9 @@ public static class Manager
     {
         if (Loaded(path))
 
-        Assembly assembly = Assembly.Load(ReadFile(path));
+            Assembly assembly = Assembly.Load(ReadFile(path));
         LocalLoaded.Add(new AssemblyDefine(assembly, path));
-4return
+        4return
         return assembly;
     }
 

--- a/Qurre/Manager.cs
+++ b/Qurre/Manager.cs
@@ -31,11 +31,10 @@ public static class Manager
     public static Assembly LoadAssembly(string path)
     {
         if (Loaded(path))
-            throw new Exception("Assembly already loaded");
 
         Assembly assembly = Assembly.Load(ReadFile(path));
         LocalLoaded.Add(new AssemblyDefine(assembly, path));
-
+4return
         return assembly;
     }
 


### PR DESCRIPTION
…d add newline at end of file

The exception for already loaded assemblies has been removed, likely to allow for silent handling or logging instead of immediate failure. A newline character is now added at the end of the file to adhere to common coding standards for file formatting.